### PR TITLE
Add a threshold argment to crate.validate()

### DIFF
--- a/test/test_crate.py
+++ b/test/test_crate.py
@@ -5,7 +5,6 @@ from rdfcrate.vocabs import dc, sdo, roc, rdf, bioschemas_drafts
 from rdflib import Literal, Graph
 import json
 from datetime import datetime
-from rocrate_validator.models import Severity
 
 TEST_CRATE = Path(__file__).parent / "test_crate"
 

--- a/test/test_crate.py
+++ b/test/test_crate.py
@@ -5,6 +5,7 @@ from rdfcrate.vocabs import dc, sdo, roc, rdf, bioschemas_drafts
 from rdflib import Literal, Graph
 import json
 from datetime import datetime
+from rocrate_validator.models import Severity
 
 TEST_CRATE = Path(__file__).parent / "test_crate"
 


### PR DESCRIPTION
Add a threshold argment to `crate.validate()` such that any issue with lower severity will become a warning rather than an exception