### PR TITLE
Fix for multi-type entities

### DIFF
--- a/src/rdfcrate/wrapper.py
+++ b/src/rdfcrate/wrapper.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Annotated, Any, Iterable, TypeVar, TYPE_CHECKING
 from rocrate_validator.models import CheckIssue
 from typing_extensions import Doc
-from rdflib import Graph, URIRef, IdentifiedNode
+from rdflib import Graph, URIRef, IdentifiedNode, RDF
 from rdfcrate.rdfprop import RdfProperty, ReverseProperty
 from rdfcrate.rdfterm import RdfTerm
 from rdfcrate.rdfclass import RdfClass, EntityArgs
@@ -71,8 +71,9 @@ class RoCrate(metaclass=ABCMeta):
         Adds custom terms to the crate context
         """
         for term in terms:
-            if self.version.version not in term.specs:
-                # Skip terms that are already in the RO-Crate context
+            # Skip terms that are already in the RO-Crate context
+            # Also skip RDF.type, as this should never be re-defined
+            if self.version.version not in term.specs and term.uri != RDF.type:
                 self.context.add_term(term.label, str(term.uri))
 
     def add_entity(

--- a/test/test_crate.py
+++ b/test/test_crate.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 
 from rdfcrate import AttachedCrate
-from rdfcrate.vocabs import dc, sdo, roc, rdf, bioschemas_drafts
+from rdfcrate.vocabs import dc, sdo, roc, rdf, bioschemas_drafts, rdfs
 from rdflib import Literal, Graph
 import json
 from datetime import datetime
+import tempfile
 
 TEST_CRATE = Path(__file__).parent / "test_crate"
 
@@ -131,3 +132,15 @@ def test_bioschemas():
             "LabProtocol": str(bioschemas_drafts.LabProtocol.term.uri)
         }
     ], "Only the terms that are used in the crate should be in the context"
+
+def test_multi_type():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        crate = AttachedCrate(tmpdir)
+        crate.add_entity(
+            "#multi_type_entity",
+            bioschemas_drafts.LabProtocol,
+            rdf.type(rdfs.Class("https://example.org/SomeOtherType")),
+        )
+
+        # We never want to redefine rdf:type
+        assert str(rdf.type.term.uri) not in crate.context.to_dict().values()


### PR DESCRIPTION
Don't ever add `rdf:type` to the context