### PR TITLE
Quality of Life Features

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@
 - Added `ruff` linter
 - Added `.validate()` and `.get_issues()` methods for easy validation of the crate [[#22](https://github.com/WEHI-SODA-Hub/RdfCrate/pull/22)]
 - Added `.to_type_property()` to `RdfType` subclasses, to facilitate multi-class entities (see `test_multi_type`)
+- Added `RdfProperty.adhoc(term=RdfTerm(...), object=...)` for defining single-use properties
 
 ## 0.3.0
 

--- a/src/rdfcrate/rdfprop.py
+++ b/src/rdfcrate/rdfprop.py
@@ -17,10 +17,10 @@ class ReverseProperty:
     """
 
     term: RdfTerm
-    subject: GraphId
+    subject: RdfType
 
-    def add_to_graph(self, graph, object: GraphId) -> None:
-        graph.add((self.subject, self.term.uri, object))
+    def add_to_graph(self, graph: Graph, object: GraphId) -> None:
+        graph.add((self.subject.id, self.term.uri, object))
 
 
 T = TypeVar("T", bound="RdfType")
@@ -37,7 +37,7 @@ class RdfProperty(Generic[T]):
     object: T
 
     @classmethod
-    def reverse(cls, subject: GraphId) -> ReverseProperty:
+    def reverse(cls, subject: RdfType) -> ReverseProperty:
         return ReverseProperty(cls.term, subject)
 
     def add_to_graph(self, graph: Graph, subject: GraphId) -> None:

--- a/src/rdfcrate/rdfprop.py
+++ b/src/rdfcrate/rdfprop.py
@@ -36,6 +36,16 @@ class RdfProperty(Generic[T]):
     term: ClassVar[RdfTerm]
     object: T
 
+    @staticmethod
+    def adhoc(term: RdfTerm, object: T) -> RdfProperty:
+        """
+        Makes an ad-hoc property class from a term.
+        """
+        subclass = type(term.label, (RdfProperty,), {
+            "term": term
+        })
+        return subclass(object=object)
+
     @classmethod
     def reverse(cls, subject: RdfType) -> ReverseProperty:
         return ReverseProperty(cls.term, subject)

--- a/src/rdfcrate/wrapper.py
+++ b/src/rdfcrate/wrapper.py
@@ -71,9 +71,12 @@ class RoCrate(metaclass=ABCMeta):
         Adds custom terms to the crate context
         """
         for term in terms:
-            if self.context.expand(term.label) == str(term.uri):
+            existing = self.context.expand(term.label)
+            if existing == str(term.uri):
                 # Skip terms that are already in the RO-Crate context
                 continue
+            if existing is not None:
+                raise ValueError('Term "{term.label}" is already defined to mean {existing}. Cannot redefine to {term.uri}.')
 
             if term.uri == RDF.type:
                 # rdf:type should never be re-defined

--- a/test/test_crate.py
+++ b/test/test_crate.py
@@ -7,6 +7,7 @@ from rdfcrate.vocabs import dc, sdo, roc, rdf, bioschemas_drafts, rdfs
 import json
 from datetime import datetime
 import tempfile
+import pytest
 
 TEST_CRATE = Path(__file__).parent / "test_crate"
 
@@ -153,3 +154,13 @@ def test_multi_type():
         assert str(rdf.type.term.uri) not in crate.context.to_dict().values()
         # But we should have the custom type in the context
         assert "https://example.org/SomeOtherType" in crate.context.to_dict().values()
+
+
+def test_redefine_term():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        crate = AttachedCrate(tmpdir)
+        # Attempting to redefine an existing term should raise a ValueError
+        with pytest.raises(ValueError):
+            crate.register_terms([
+                RdfTerm("https://example.org/Thing", "Thing"),
+            ])

--- a/test/test_crate.py
+++ b/test/test_crate.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from rdfcrate import AttachedCrate
+from rdfcrate import AttachedCrate, RdfProperty
 from rdflib import Literal, Graph, BNode, URIRef
 from rdfcrate.rdfterm import RdfTerm
 from rdfcrate.vocabs import dc, sdo, roc, rdf, bioschemas_drafts, rdfs
@@ -176,3 +176,16 @@ def test_reverse_prop(empty_crate: AttachedCrate):
         sdo.hasPart.reverse(empty_crate.root_data_entity)
     )
     assert (empty_crate.root_data_entity.id,  sdo.hasPart.term.uri, URIRef("#thing")) in empty_crate.graph
+
+def test_adhoc_term(empty_crate: AttachedCrate):
+    """
+    Test that we can define terms on the fly and use them in properties.
+    """
+    thing = empty_crate.add_entity(
+        sdo.Thing("#thing"),
+        RdfProperty.adhoc(
+            term=RdfTerm("https://example.org/myProp"),
+            object=sdo.Text("value")
+        )
+    )
+    assert (thing.id, URIRef("https://example.org/myProp"), Literal("value")) in empty_crate.graph


### PR DESCRIPTION
- Throw error when redefining terms
- Fix for .reverse() properties. They now accept an RdfType instance
- Add RdfProperty.adhoc() for easy term definition