### PR TITLE
Encode filepaths

### DIFF
--- a/src/rdfcrate/wrapper.py
+++ b/src/rdfcrate/wrapper.py
@@ -14,6 +14,7 @@ from os import stat
 from abc import ABCMeta, abstractmethod
 from rdflib.plugins.shared.jsonld.context import Context
 from rdfcrate.vocabs import dc, schemaorg, rocrate
+from urllib.parse import quote
 import warnings
 
 if TYPE_CHECKING:
@@ -364,7 +365,7 @@ class AttachedCrate(RoCrate):
         if existing and not path.exists():
             raise ValueError(f"Path {path} does not exist")
 
-        return path.resolve(), URIRef(path.relative_to(self.root).as_posix())
+        return path.resolve(), URIRef(quote(path.relative_to(self.root).as_posix()))
 
     def register_file(
         self,

--- a/test/test_crate.py
+++ b/test/test_crate.py
@@ -232,3 +232,12 @@ def test_adhoc_class(empty_crate: AttachedCrate):
         ExampleClass("#thing"),
     )
     assert (URIRef("#thing"), RDF.type, ExampleClass.term.uri) in empty_crate.graph
+
+def test_spaces_in_path(empty_crate: AttachedCrate):
+    """
+    Test that we can register a file with spaces in the path.
+    """
+    path = empty_crate.root / "file with spaces.txt"
+    path.touch()
+    empty_crate.register_file(path)
+    assert (URIRef("file%20with%20spaces.txt"), rdf.type.term.uri, roc.File.term.uri) in empty_crate.graph


### PR DESCRIPTION
Closes #44.

This probably over-encodes valid IRIs, but this is an easy fix for now.